### PR TITLE
Potentially fix eslint and prettier conflict

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,7 +7,6 @@ module.exports = {
     "plugin:vue/vue3-essential",
     "eslint:recommended",
     "@vue/eslint-config-typescript",
-    "@vue/eslint-config-prettier",
   ],
   parserOptions: {
     ecmaVersion: "latest",

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,13 +5,7 @@ import TheWelcome from "./components/TheWelcome.vue";
 
 <template>
   <header>
-    <img
-      alt="Vue logo"
-      class="logo"
-      src="./assets/logo.svg"
-      width="125"
-      height="125"
-    />
+    <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
 
     <div class="wrapper">
       <HelloWorld msg="You did it!" />


### PR DESCRIPTION
The default eslint and prettier configuration from create-vue has some kind of conflict - one of them (prettier) wants to turn the long line into a multi-line, while the other (eslint?) doesn't

![image](https://user-images.githubusercontent.com/4131165/191177803-df7b6121-f0cb-4d33-a74e-ffc6f3d9802b.png)

This is with the ESLint and Volar VSCode extensions.

I should go complain to https://github.com/vuejs/create-vue/issues about this if this is reproducible.