### PR TITLE
Get all commits via pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
-    "ci:lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore",
+    "ci:lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --max-warnings=0 --ignore-path .gitignore",
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {

--- a/src/components/CommitStats.vue
+++ b/src/components/CommitStats.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from "vue";
-import { getCommits, type Commits } from "../services/githubService";
+import { getAllCommits, type Commits } from "../services/githubService";
 import BarChart from "../components/BarChart";
 
 const commits = ref<Commits | null>(null);
 
 const loadCommits = async () => {
   commits.value = null;
-  const res = await getCommits({
+  const res = await getAllCommits({
     owner: "lrdwhyt",
     repo: "coscheduler",
   });

--- a/src/services/githubService.ts
+++ b/src/services/githubService.ts
@@ -40,5 +40,5 @@ export const getAllCommits = async (
     pageNumber++;
   } while (pageCommits.length > 0);
 
-  return allCommits // OoOoO I forgot a semicolon
+  return allCommits; // OoOoO I forgot a semicolon
 };

--- a/src/services/githubService.ts
+++ b/src/services/githubService.ts
@@ -18,10 +18,27 @@ const GET_COMMITS_URL = "GET /repos/{owner}/{repo}/commits";
 type GetCommitsParameters = Endpoints[typeof GET_COMMITS_URL]["parameters"];
 type GetCommitsResponse = Endpoints[typeof GET_COMMITS_URL]["response"];
 export type Commits = GetCommitsResponse["data"];
+export type Commit = Commits[number];
 
-export const getCommits = async (params: GetCommitsParameters) => {
+const getCommits = async (params: GetCommitsParameters): Promise<Commit[]> => {
   const octokit = new Octokit();
   const res = await octokit.request(GET_COMMITS_URL, params);
 
   return res.data;
+};
+
+export const getAllCommits = async (
+  params: GetCommitsParameters
+): Promise<Commit[]> => {
+  let pageNumber = 1;
+  const allCommits: Commit[] = [];
+  let pageCommits: Commit[];
+  do {
+    pageCommits = await getCommits({ ...params, page: pageNumber });
+    console.log({ pageNumber, n: pageCommits.length });
+    allCommits.push(...pageCommits);
+    pageNumber++;
+  } while (pageCommits.length > 0);
+
+  return allCommits;
 };

--- a/src/services/githubService.ts
+++ b/src/services/githubService.ts
@@ -40,5 +40,5 @@ export const getAllCommits = async (
     pageNumber++;
   } while (pageCommits.length > 0);
 
-  return allCommits;
+  return allCommits // OoOoO I forgot a semicolon
 };


### PR DESCRIPTION
To address https://github.com/kevinyou/coschedulerscheduler/issues/6

By default, the [list commits endpoint](https://docs.github.com/en/rest/commits/commits#list-commits) is called with `per_page` 30 and `page` 0, which is why it would get the first (or last? 🤷) 30 commits.

Here, we repeatedly call this endpoint with increasing `page` until we get a page that has no commits.