### PR TITLE
Potentially fix gh-pages cache issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type-check": "vue-tsc --noEmit",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
     "ci:lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --max-warnings=0 --ignore-path .gitignore",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages-clean && gh-pages -d dist"
   },
   "dependencies": {
     "chart.js": "^3.9.1",


### PR DESCRIPTION
I'm not entirely sure why this is necessary, I was just blindly following tips from https://www.npmjs.com/package/gh-pages#Tips

Without this change, running `npm run deploy` twice causes weirdness where the cache itself gets pushed into the  `gh-pages` branch instead of the actual files